### PR TITLE
ダブルスのメンバー表示を外側に寄せた

### DIFF
--- a/front/app/_components/Members.tsx
+++ b/front/app/_components/Members.tsx
@@ -71,18 +71,26 @@ function Row({ member, handleDelete }: {
                           <TableCell>
                           <div className="w-full flex items-center">
                             <div className="w-5/12 flex justify-start">
-                              <div>
-                                <p>{historyRow.player_1}</p>
-                                <p>{historyRow.player_2}</p>
+                              <div className="w-full">
+                                <div className="flex justify-start">
+                                  <p>{historyRow.player_1}</p>
+                                </div>
+                                <div className="flex justify-start">
+                                  <p>{historyRow.player_2}</p>
+                                </div>
                               </div>
                             </div>
                             <div className="w-1/6 flex justify-center">
                               <p>{historyRow.score_12} - {historyRow.score_34}</p>
                             </div>
                             <div className="w-5/12 flex justify-end">
-                              <div>
-                                <p>{historyRow.player_3}</p>
-                                <p>{historyRow.player_4}</p>
+                              <div className="w-full">
+                                <div className="flex justify-end">
+                                  <p>{historyRow.player_3}</p>
+                                </div>
+                                <div className="flex justify-end">
+                                  <p>{historyRow.player_4}</p>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/front/app/records/_component/Records.tsx
+++ b/front/app/records/_component/Records.tsx
@@ -117,18 +117,26 @@ function TabComponent({singlesRecords, handleSinglesRecordEditDialogOpen,
                   >
                     <div className="w-5/6 flex items-center">
                       <div className="w-2/5 flex justify-start">
-                        <div>
-                          <p>{doublesRecord?.player_1}</p>
-                          <p>{doublesRecord?.player_2}</p>
+                        <div className="w-full">
+                          <div className="flex justify-start">
+                            <p>{doublesRecord?.player_1}</p>
+                          </div>
+                          <div className="flex justify-start">
+                            <p>{doublesRecord?.player_2}</p>
+                          </div>
                         </div>
                       </div>
                       <div className="w-1/5 flex justify-center">
                         <p>{doublesRecord?.score_12} - {doublesRecord?.score_34}</p>
                       </div>
                       <div className="w-2/5 flex justify-end">
-                        <div>
-                          <p>{doublesRecord?.player_3}</p>
-                          <p>{doublesRecord?.player_4}</p>
+                        <div className="w-full">
+                          <div className="flex justify-end">
+                            <p>{doublesRecord?.player_3}</p>
+                          </div>
+                          <div className="flex justify-end">
+                            <p>{doublesRecord?.player_4}</p>
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
試合記録のダブルスの表示
|Before|After|
|:-:|:-:|
|<img width="320" alt="試合記録ダブルス修正前" src="https://github.com/neko967/badminton-app/assets/113199838/332bec29-eba8-4768-b72b-e229487e1e59">|<img width="320" alt="試合記録ダブルス修正後" src="https://github.com/neko967/badminton-app/assets/113199838/7f21b991-d372-42c7-8906-de58d7f7523c">|


試合履歴のダブルスの表示
|Before|After|
|:-:|:-:|
|<img width="320" alt="試合履歴ダブルス修正前" src="https://github.com/neko967/badminton-app/assets/113199838/6a9fd4bf-0846-425f-a6a3-3e6348b4b719">|<img width="320" alt="試合履歴ダブルス修正後" src="https://github.com/neko967/badminton-app/assets/113199838/17612af6-c3f0-48a0-8e5f-2390ba3bee9d">|

Closed #22 
