### PR TITLE
ログインしていない状態でも、メンバー情報や試合記録をいじれるようにした

### DIFF
--- a/front/app/members/[slug]/_components/AddPersonDialog.tsx
+++ b/front/app/members/[slug]/_components/AddPersonDialog.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Dialog from '@mui/material/Dialog';
 import { useState } from "react";
-import { useSession } from 'next-auth/react';
 import type { Member } from '@/app/types/index';
 
 type FetchDataType = () => Promise<void>;
@@ -16,24 +15,21 @@ interface DialogSelectProps {
 export default function DialogSelect({ addPersonOpen, handleAddPersonClose, fetchMemberData, params }: DialogSelectProps) {
   const [member, setMember] = useState({} as Member);
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/members`;
-  const { data: session, status } = useSession();
 
   const handleOnSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (session) {
-      await fetch(API_URL, {
-        method: "POST",
-        headers: {
-          'slug': `${params.slug}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: member.name,
-        }),
-      }).then(() => {
-        fetchMemberData();
-      });
-    }
+    await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        'slug': `${params.slug}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: member.name,
+      }),
+    }).then(() => {
+      fetchMemberData();
+    });
   };
 
   return (

--- a/front/app/members/[slug]/_components/DoublesBeforeSendPareDialog.tsx
+++ b/front/app/members/[slug]/_components/DoublesBeforeSendPareDialog.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -27,7 +26,6 @@ export default function DoublesBeforeSendPareDialog({
 }: DoublesBeforeSendPareDialogProps) {
 
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/doubles_records`;
-  const { data: session, status } = useSession();
   const router = useRouter();
 
   const handlePareSubmit = async () => {
@@ -37,21 +35,19 @@ export default function DoublesBeforeSendPareDialog({
       const member3 = playersWithStatus.find((item: Member) => item.name === makedPare[i][2]);
       const member4 = playersWithStatus.find((item: Member) => item.name === makedPare[i][3]);
 
-      if (session) {
-        await fetch(API_URL, {
-          method: "POST",
-          headers: {
-            'slug': `${params.slug}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            member_1_id: member1?.id,
-            member_2_id: member2?.id,
-            member_3_id: member3?.id,
-            member_4_id: member4?.id,
-          }),
-        })
-      }
+      await fetch(API_URL, {
+        method: "POST",
+        headers: {
+          'slug': `${params.slug}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          member_1_id: member1?.id,
+          member_2_id: member2?.id,
+          member_3_id: member3?.id,
+          member_4_id: member4?.id,
+        }),
+      })
     }
     router.push(`/records/${params.slug}?set_value=1`);
   };

--- a/front/app/members/[slug]/_components/SinglesBeforeSendPareDialog.tsx
+++ b/front/app/members/[slug]/_components/SinglesBeforeSendPareDialog.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -26,7 +25,6 @@ export default function SinglesBeforeSendPareDialog({
   params,
 }: SinglesBeforeSendPareDialogProps) {
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/singles_records`;
-  const { data: session, status } = useSession();
   const router = useRouter();
 
   const handlePareSubmit = async () => {
@@ -34,19 +32,17 @@ export default function SinglesBeforeSendPareDialog({
       const member1 = playersWithStatus.find((item: Member) => item.name === makedPare[i][0]);
       const member2 = playersWithStatus.find((item: Member) => item.name === makedPare[i][1]);
 
-      if (session) {
-        await fetch(API_URL, {
-          method: "POST",
-          headers: {
-            'slug': `${params.slug}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            member_1_id: member1?.id,
-            member_2_id: member2?.id,
-          }),
-        })
-      }
+      await fetch(API_URL, {
+        method: "POST",
+        headers: {
+          'slug': `${params.slug}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          member_1_id: member1?.id,
+          member_2_id: member2?.id,
+        }),
+      })
     }
     router.push(`/records/${params.slug}?set_value=0`);
   };

--- a/front/app/members/[slug]/page.tsx
+++ b/front/app/members/[slug]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useSession } from 'next-auth/react';
 import Members from './_components/Members';
 import SpeedDialTooltipOpen from './_components/SpeedDialTooltipOpen';
 import BottomNavigation from '@/app/_components/_shared/BottomNavigation';
@@ -10,7 +9,6 @@ import type { Member } from '@/app/types/index';
 export default function Home({ params }: { params: { slug: string } }) {
   const [members, setMembers] = useState([] as Member[]);
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/members`;
-  const { data: session, status } = useSession();
 
   const fetchMemberData = useCallback(async () => {
     const headers = {
@@ -23,13 +21,11 @@ export default function Home({ params }: { params: { slug: string } }) {
     });
     const data = await response.json();
       setMembers(data);
-  }, [session]);
+  }, []);
 
   useEffect(() => {
-    if (session) {
-      fetchMemberData();
-    }
-  }, [session, fetchMemberData]);
+    fetchMemberData();
+  }, [fetchMemberData]);
   
   const handleDelete = async (id: number) => {
     await fetch(`${API_URL}/${id}`, {
@@ -41,24 +37,16 @@ export default function Home({ params }: { params: { slug: string } }) {
 
   return (
     <>
-      {session ?
-        <>
-          <Members
-            members={members}
-            handleDelete={handleDelete}
-          />
-          <SpeedDialTooltipOpen
-            members={members}
-            fetchMemberData={fetchMemberData}
-            params={params}
-          />
-          <BottomNavigation params={params} bottomValue={0}/>
-        </>
-      :
-        <div className="text-start px-6 mt-6">
-          <p>ログインをしてください</p>
-        </div>
-      }
+      <Members
+        members={members}
+        handleDelete={handleDelete}
+      />
+      <SpeedDialTooltipOpen
+        members={members}
+        fetchMemberData={fetchMemberData}
+        params={params}
+      />
+      <BottomNavigation params={params} bottomValue={0}/>
     </>
   );
 }

--- a/front/app/records/[slug]/_components/DoublesRecordEditDialog.tsx
+++ b/front/app/records/[slug]/_components/DoublesRecordEditDialog.tsx
@@ -11,7 +11,6 @@ import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { useEffect, useState } from "react";
-import { useSession } from 'next-auth/react';
 import type { Member } from '@/app/types/index';
 
 interface DoublesRecordEditDialogProps {
@@ -33,7 +32,6 @@ export default function DoublesRecordEditDialog({
 }: DoublesRecordEditDialogProps) {
 
   const API_URL_DOUBLES_RECORD = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/doubles_records`;
-  const { data: session, status } = useSession();
 
   const [score_12_plus_100_with_none, setScore_12_plus_100_with_none] = useState<number | string>('');
   const handleScoreOneTwoChange = (event: SelectChangeEvent<number | string>) => {
@@ -53,24 +51,22 @@ export default function DoublesRecordEditDialog({
     const score_12 = Number(score_12_plus_100_with_none) - 100;
     const score_34 = Number(score_34_plus_100_with_none) - 100;
 
-    if (session) {
-      await fetch(`${API_URL_DOUBLES_RECORD}/${id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          player_1_id: player_1_id,
-          player_2_id: player_2_id,
-          score_12: score_12,
-          player_3_id: player_3_id,
-          player_4_id: player_4_id,
-          score_34: score_34,
-        }),
-      }).then(() => {
-        fetchDoublesData();
-      });
-    }
+    await fetch(`${API_URL_DOUBLES_RECORD}/${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        player_1_id: player_1_id,
+        player_2_id: player_2_id,
+        score_12: score_12,
+        player_3_id: player_3_id,
+        player_4_id: player_4_id,
+        score_34: score_34,
+      }),
+    }).then(() => {
+      fetchDoublesData();
+    });
   };
 
   const handleScoreReset = () => {

--- a/front/app/records/[slug]/_components/Records.tsx
+++ b/front/app/records/[slug]/_components/Records.tsx
@@ -3,7 +3,6 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
 import { useCallback, useEffect, useState, Suspense } from "react";
-import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import EditIcon from '@mui/icons-material/Edit';
 import SinglesRecordEditDialog from './SinglesRecordEditDialog';
@@ -177,7 +176,6 @@ function TabComponent({
 }
 
 export default function Records({ params }: { params: { slug: string } }) {
-  const { data: session, status } = useSession();
   const [singlesRecords, setSinglesRecords] = useState<any[]>([]);
   const API_URL_SINGLES_RECORD = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/singles_records`;
   const fetchSinglesData = useCallback(async () => {
@@ -191,13 +189,11 @@ export default function Records({ params }: { params: { slug: string } }) {
     });
     const data = await response.json();
     setSinglesRecords(data);
-  }, [session]);
+  }, []);
 
   useEffect(() => {
-    if (session) {
-      fetchSinglesData();
-    }
-  }, [session, fetchSinglesData]);
+    fetchSinglesData();
+  }, [fetchSinglesData]);
 
   const [singlesRecord_id, setSinglesRecord_id] = useState<number>(0);
   const [singlesRecordEditDialogOpen, setSinglesRecordEditDialogOpen] = useState(false);
@@ -222,13 +218,11 @@ export default function Records({ params }: { params: { slug: string } }) {
     });
     const data = await response.json();
     setDoublesRecords(data);
-  }, [session]);
+  }, []);
 
   useEffect(() => {
-    if (session) {
-      fetchDoublesData();
-    }
-  }, [session, fetchDoublesData]);
+    fetchDoublesData();
+  }, [fetchDoublesData]);
 
   const [doublesRecord_id, setDoublesRecord_id] = useState<number>(0);
   const [doublesRecordEditDialogOpen, setDoublesRecordEditDialogOpen] = useState(false);
@@ -254,13 +248,11 @@ export default function Records({ params }: { params: { slug: string } }) {
     });
     const data = await response.json();
       setMembers(data);
-  }, [session]);
+  }, []);
 
   useEffect(() => {
-    if (session) {
-      fetchMemberData();
-    }
-  }, [session, fetchMemberData]);
+    fetchMemberData();
+  }, [fetchMemberData]);
 
   return (
     <>

--- a/front/app/records/[slug]/_components/SinglesRecordEditDialog.tsx
+++ b/front/app/records/[slug]/_components/SinglesRecordEditDialog.tsx
@@ -11,7 +11,6 @@ import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { useEffect, useState } from "react";
-import { useSession } from 'next-auth/react';
 import type { Member } from '@/app/types/index';
 
 interface SinglesRecordEditDialogProps {
@@ -33,7 +32,6 @@ export default function SinglesRecordEditDialog({
 }: SinglesRecordEditDialogProps) {
 
   const API_URL_SINGLESRECORD = `${process.env.NEXT_PUBLIC_API_URL}/api/${process.env.NEXT_PUBLIC_API_VERSION}/singles_records`;
-  const { data: session, status } = useSession();
 
   const [score_1_plus_100_with_none, setScore_1_plus_100_with_none] = useState<number | string>('');
   const handleScoreOneChange = (event: SelectChangeEvent<number | string>) => {
@@ -53,22 +51,20 @@ export default function SinglesRecordEditDialog({
     const score_1 = Number(score_1_plus_100_with_none) - 100;
     const score_2 = Number(score_2_plus_100_with_none) - 100;
 
-    if (session) {
-      await fetch(`${API_URL_SINGLESRECORD}/${id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          player_1_id: player_1_id,
-          score_1: score_1,
-          player_2_id: player_2_id,
-          score_2: score_2,
-        }),
-      }).then(() => {
-        fetchSinglesData();
-      });
-    }
+    await fetch(`${API_URL_SINGLESRECORD}/${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        player_1_id: player_1_id,
+        score_1: score_1,
+        player_2_id: player_2_id,
+        score_2: score_2,
+      }),
+    }).then(() => {
+      fetchSinglesData();
+    });
   };
 
   const handleScoreReset = () => {

--- a/front/app/records/[slug]/page.tsx
+++ b/front/app/records/[slug]/page.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 import Records from './_components/Records';
-import { useSession } from 'next-auth/react';
 import BottomNavigation from '@/app/_components/_shared/BottomNavigation';
 
 export default function Home({ params }: { params: { slug: string } }) {
-  const { data: session, status } = useSession();
 
   return (
     <>
-      {session ?
-        <>
-          <Records params={params}/>
-          <BottomNavigation params={params} bottomValue={1}/>
-        </>
-      :
-        <div className="text-start px-6 mt-6">
-          <p>ログインをしてください</p>
-        </div>
-      } 
+      <Records params={params}/>
+      <BottomNavigation params={params} bottomValue={1}/>
     </>
   );
 }


### PR DESCRIPTION
課題：URLをシェアするだけで色々な人がデータを扱えるようにする過程で、ログインをしなくてもデータの加筆修正ができるようになっても良くなった。ログインを挟むと面倒なので、ログインが不要なところに関してはログインなしでできるようにした。

解決策：if (session) {}を外すことによって、ログインをしていなくてもデータを表示したり、書き込みができるようにした。

ログインしていない状態で"localhost:8000/members/QdXrgnVEyf4S4ckJuJ848xxHAZnc1nwjzG8MHZfKPp9j" にアクセスした結果
|before|after|
|:-:|:-:|
|<img width="320" alt="before" src="https://i.gyazo.com/bf7166e4feb15dad8917bf1561508475.jpg">|<img width="320" alt="after" src="https://i.gyazo.com/afac98048d3ab0373e33612109ce8adc.jpg">|

ログインしていない状態で"localhost:8000/records/QdXrgnVEyf4S4ckJuJ848xxHAZnc1nwjzG8MHZfKPp9j" にアクセスした結果
|before|after|
|:-:|:-:|
|<img width="320" alt="before" src="https://i.gyazo.com/bf7166e4feb15dad8917bf1561508475.jpg">|<img width="320" alt="after" src="https://i.gyazo.com/1976a06c341f80f9244d56534512ae9e.jpg">|

Close #31 