### PR TITLE
グループ一覧に、人数と最終更新日の表示を追加

### DIFF
--- a/back/app/controllers/api/v1/members_controller.rb
+++ b/back/app/controllers/api/v1/members_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MembersController < ApplicationController
   wrap_parameters false
-  before_action :set_current_group, only: %i[index create]
+  before_action :set_current_group, only: %i[index create destroy]
 
   def index
     render json: @current_group.members, methods: :history, status: :ok
@@ -9,6 +9,7 @@ class Api::V1::MembersController < ApplicationController
   def create
     member = @current_group.members.build(member_params)
     if member.save
+      @current_group.update(number_of_people:  @current_group.number_of_people + 1)
       render json: member, status: :created
     else
       render json: member.errors, status: :unprocessable_entity
@@ -16,8 +17,9 @@ class Api::V1::MembersController < ApplicationController
   end
 
   def destroy
-    member = Member.find(params[:id])
+    member = @current_group.members.find(params[:id])
     member.destroy
+    @current_group.update(number_of_people: @current_group.number_of_people - 1)
     head :no_content
   end
 

--- a/back/db/migrate/20240529183656_create_groups.rb
+++ b/back/db/migrate/20240529183656_create_groups.rb
@@ -1,9 +1,10 @@
 class CreateGroups < ActiveRecord::Migration[7.1]
   def change
     create_table :groups do |t|
-      t.string :name
+      t.string :name,      null: false
       t.string :slug,      null: false
       t.string :admin_uid, null: false
+      t.integer :number_of_people, default: 0, null: false
 
       t.timestamps
     end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -34,9 +34,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_29_185041) do
   end
 
   create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.string "slug", null: false
     t.string "admin_uid", null: false
+    t.integer "number_of_people", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_groups_on_slug", unique: true

--- a/front/app/_components/AddGroupDialog.tsx
+++ b/front/app/_components/AddGroupDialog.tsx
@@ -10,6 +10,9 @@ interface Group {
   name: string;
   slug: string;
   admin_uid: string;
+  number_of_people: number;
+  created_at: Date;
+  updated_at: Date;
 }
 
 interface DialogSelectProps {

--- a/front/app/_components/GroupEditDialog.tsx
+++ b/front/app/_components/GroupEditDialog.tsx
@@ -8,6 +8,9 @@ interface Group {
   name: string;
   slug: string;
   admin_uid: string;
+  number_of_people: number;
+  created_at: Date;
+  updated_at: Date;
 }
 
 interface GroupEditDialogProps {

--- a/front/app/_components/Groups.tsx
+++ b/front/app/_components/Groups.tsx
@@ -16,15 +16,17 @@ interface Group {
   name: string;
   slug: string;
   admin_uid: string;
+  number_of_people: number;
+  created_at: Date;
+  updated_at: Date;
 }
-const bull = (
-  <Box
-    component="span"
-    sx={{ display: 'inline-block', mx: '2px', transform: 'scale(0.8)' }}
-  >
-    •
-  </Box>
-);
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${month}/${day}`;
+};
 
 export default function Members({groups, handleGroupDelete, fetchGroupsData}: 
                                 {groups: Group[]; handleGroupDelete: (id: number) => void; fetchGroupsData: () => void; }) {
@@ -54,15 +56,12 @@ export default function Members({groups, handleGroupDelete, fetchGroupsData}:
                       <Card sx={{ minWidth: 275 }} variant="outlined">
                         <CardContent onClick={() => router.push(`/members/${group.slug}`)}>
                           <Typography sx={{ fontSize: 14 }} color="text.secondary" gutterBottom>
-                            Word of the Day
+                            {`最終更新日: ${formatDate(group.updated_at.toString())}`}
                           </Typography>
                           <Typography variant="h5" component="div">
-                            <button >
-                              <p>{group.name}</p>
+                            <button>
+                              <p>{`${group.name} (${group.number_of_people})`}</p>
                             </button>
-                          </Typography>
-                          <Typography sx={{ mb: 1.5 }} color="text.secondary">
-                            メンバー数：{'"a benevolent smile"'}
                           </Typography>
                         </CardContent>
                         {group.admin_uid == session?.user?.id ?

--- a/front/app/_components/SpeedDialTooltipOpen.tsx
+++ b/front/app/_components/SpeedDialTooltipOpen.tsx
@@ -14,6 +14,9 @@ interface Group {
   name: string;
   slug: string;
   admin_uid: string;
+  number_of_people: number;
+  created_at: Date;
+  updated_at: Date;
 }
 
 interface SpeedDialTooltipOpenProps {

--- a/front/app/members/[slug]/page.tsx
+++ b/front/app/members/[slug]/page.tsx
@@ -28,8 +28,13 @@ export default function Home({ params }: { params: { slug: string } }) {
   }, [fetchMemberData]);
   
   const handleDelete = async (id: number) => {
+    const headers = {
+      'slug': `${params.slug}`,
+      'Content-Type': 'application/json',
+    };
     await fetch(`${API_URL}/${id}`, {
       method: "DELETE",
+      headers: headers,
     }).then(() => {
       fetchMemberData();
     });

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -10,6 +10,9 @@ interface Group {
   name: string;
   slug: string;
   admin_uid: string;
+  number_of_people: number;
+  created_at: Date;
+  updated_at: Date;
 }
 
 export default function Home() {


### PR DESCRIPTION
Fix #45 
以下の３つについて取り組んだ
- [x] グループ名に人数を表示する
- [x] groupsテーブルにnumber_of_peopleのカラムを追加
- [x] 最新の更新日を表示

変更後の表示
[![Image from Gyazo](https://i.gyazo.com/e8c90a1926dfa1db8fb2bd2c0c3ceea9.jpg)](https://gyazo.com/e8c90a1926dfa1db8fb2bd2c0c3ceea9)