### PR TITLE
グループ一覧の表示の整理

### DIFF
--- a/front/app/_components/Groups.tsx
+++ b/front/app/_components/Groups.tsx
@@ -65,10 +65,12 @@ export default function Members({groups, handleGroupDelete, fetchGroupsData}:
                           </Typography>
                         </CardContent>
                         {group.admin_uid == session?.user?.id ?
-                          <CardActions>
-                            <Button size="small" onClick={() => handleGroupEditDialogOpen(group.id)}>グループ名を変更</Button>
-                            <Button size="small" onClick={() => handleGroupDelete(group.id)}>グループを削除</Button>
-                          </CardActions>
+                          <div className="flex justify-end">
+                            <CardActions>
+                              <Button size="small" onClick={() => handleGroupEditDialogOpen(group.id)}>グループ名を変更</Button>
+                              <Button size="small" onClick={() => handleGroupDelete(group.id)}>グループを削除</Button>
+                            </CardActions>
+                          </div>
                         :
                           undefined
                         }

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -38,13 +38,16 @@ export default function Home() {
       fetchGroupsData();
     }
   }, [session, fetchGroupsData]);
-  
+
   const handleGroupDelete = async (id: number) => {
-    await fetch(`${API_URL}/${id}`, {
-      method: "DELETE",
-    }).then(() => {
-      fetchGroupsData();
-    });
+    const name = prompt(`グループを削除すると、今までのメンバーと試合記録が失われます。グループを削除する場合は、下の記入欄に"${groups.find(group => group.id === id)?.name}"と入力してください。`);
+    if (name == groups.find(group => group.id === id)?.name) {
+      await fetch(`${API_URL}/${id}`, {
+        method: "DELETE",
+      }).then(() => {
+        fetchGroupsData();
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
Fix #45

- [x] 「グループを削除する」ボタンを右に寄せて押しづらくする
- [x]  「グループを削除する」ボタンを押したときに、確認ダイアログを開くようにする

|編集と削除ボタンを右に寄せた|削除するときに確認ダイアログを表示|
|:-:|:-:|
|<img width="320" alt="before" src="https://i.gyazo.com/71bd821c6dacbdfb3776e81a06f7e9da.jpg">|<img width="320" alt="after" src="https://i.gyazo.com/ce94e9cad0bb42162fdc64e8cc354774.jpg">|